### PR TITLE
Add installation script for Linux and macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ Currently supports:
 
 ## Installation
 
+### Install Script (Linux/macOS)
+
+```bash
+curl -sSL https://raw.githubusercontent.com/broothie/ok/main/install.sh | sh
+```
+
+Or download and inspect first:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/broothie/ok/main/install.sh -o install.sh
+sh install.sh
+```
+
 ### Homebrew
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+set -e
+
+# ok installer script
+# Usage: curl -sSL https://raw.githubusercontent.com/broothie/ok/main/install.sh | sh
+
+REPO="broothie/ok"
+INSTALL_DIR="/usr/local/bin"
+BINARY_NAME="ok"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+    printf "${GREEN}==>${NC} %s\n" "$1"
+}
+
+log_warn() {
+    printf "${YELLOW}Warning:${NC} %s\n" "$1"
+}
+
+log_error() {
+    printf "${RED}Error:${NC} %s\n" "$1" >&2
+}
+
+# Detect OS
+detect_os() {
+    case "$(uname -s)" in
+        Linux*)     echo "Linux";;
+        Darwin*)    echo "Darwin";;
+        *)
+            log_error "Unsupported operating system: $(uname -s)"
+            exit 1
+            ;;
+    esac
+}
+
+# Detect architecture
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)   echo "x86_64";;
+        aarch64|arm64)  echo "arm64";;
+        *)
+            log_error "Unsupported architecture: $(uname -m)"
+            exit 1
+            ;;
+    esac
+}
+
+# Get latest release version from GitHub
+get_latest_version() {
+    if command -v curl >/dev/null 2>&1; then
+        curl -sSf https://api.github.com/repos/${REPO}/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO- https://api.github.com/repos/${REPO}/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    else
+        log_error "Neither curl nor wget found. Please install one of them."
+        exit 1
+    fi
+}
+
+# Download file
+download_file() {
+    url=$1
+    output=$2
+
+    if command -v curl >/dev/null 2>&1; then
+        curl -sSL "$url" -o "$output"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q "$url" -O "$output"
+    fi
+}
+
+main() {
+    log_info "Installing ok..."
+
+    # Detect system
+    OS=$(detect_os)
+    ARCH=$(detect_arch)
+    log_info "Detected OS: $OS, Architecture: $ARCH"
+
+    # Get latest version
+    log_info "Fetching latest release..."
+    VERSION=$(get_latest_version)
+    if [ -z "$VERSION" ]; then
+        log_error "Failed to fetch latest version"
+        exit 1
+    fi
+    log_info "Latest version: $VERSION"
+
+    # Construct download URL
+    ARCHIVE_NAME="ok_${OS}_${ARCH}.tar.gz"
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE_NAME}"
+
+    # Create temp directory
+    TMP_DIR=$(mktemp -d)
+    trap "rm -rf $TMP_DIR" EXIT
+
+    # Download archive
+    log_info "Downloading $ARCHIVE_NAME..."
+    ARCHIVE_PATH="$TMP_DIR/$ARCHIVE_NAME"
+    if ! download_file "$DOWNLOAD_URL" "$ARCHIVE_PATH"; then
+        log_error "Failed to download from $DOWNLOAD_URL"
+        exit 1
+    fi
+
+    # Extract archive
+    log_info "Extracting archive..."
+    tar -xzf "$ARCHIVE_PATH" -C "$TMP_DIR"
+
+    # Determine install directory
+    if [ -w "$INSTALL_DIR" ]; then
+        DEST="$INSTALL_DIR/$BINARY_NAME"
+    elif [ -w "$HOME/.local/bin" ] || mkdir -p "$HOME/.local/bin" 2>/dev/null; then
+        INSTALL_DIR="$HOME/.local/bin"
+        DEST="$INSTALL_DIR/$BINARY_NAME"
+        log_warn "Installing to $HOME/.local/bin (no write access to /usr/local/bin)"
+        log_warn "Make sure $HOME/.local/bin is in your PATH"
+    else
+        log_error "No writable install directory found. Try running with sudo."
+        exit 1
+    fi
+
+    # Install binary
+    log_info "Installing to $DEST..."
+    mv "$TMP_DIR/$BINARY_NAME" "$DEST"
+    chmod +x "$DEST"
+
+    # Verify installation
+    if command -v "$BINARY_NAME" >/dev/null 2>&1; then
+        VERSION_OUTPUT=$("$BINARY_NAME" --version 2>&1 || echo "")
+        log_info "✓ Successfully installed ok!"
+        [ -n "$VERSION_OUTPUT" ] && echo "$VERSION_OUTPUT"
+    else
+        log_warn "Installation complete, but 'ok' is not in your PATH"
+        log_warn "Add $INSTALL_DIR to your PATH or run: export PATH=\"$INSTALL_DIR:\$PATH\""
+    fi
+}
+
+main


### PR DESCRIPTION
## Summary
This PR adds a shell-based installer script that enables users to easily install the `ok` binary on Linux and macOS systems using a single curl command.

## Key Changes
- **New `install.sh` script** that automates the installation process:
  - Detects the operating system (Linux/Darwin) and architecture (x86_64/arm64)
  - Fetches the latest release version from GitHub API
  - Downloads the appropriate pre-built binary archive
  - Extracts and installs the binary to `/usr/local/bin` or `~/.local/bin` (with fallback)
  - Verifies successful installation and provides helpful PATH configuration guidance
  - Includes colored output for better user experience and error handling

- **Updated README.md** with installation instructions:
  - Added "Install Script" section as the primary installation method
  - Provided both direct piped installation and download-first options
  - Positioned before Homebrew instructions

## Implementation Details
- The script uses `set -e` for fail-fast behavior
- Supports both `curl` and `wget` for maximum compatibility
- Implements graceful fallback to `~/.local/bin` if `/usr/local/bin` is not writable
- Includes proper cleanup with trap for temporary directories
- Provides informative logging with color-coded messages (info, warning, error)
- Validates installation by checking if the binary is in PATH and can execute

https://claude.ai/code/session_01REYbxLz4ed6k13PvwTQSno