### PR TITLE
Skip ignored directories during file discovery

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"sort"
@@ -15,6 +16,41 @@ import (
 	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
 )
+
+// ignoredDirs contains directory names that should be skipped during file discovery.
+var ignoredDirs = map[string]bool{
+	".git":         true,
+	".hg":          true,
+	".svn":         true,
+	"node_modules": true,
+}
+
+// skipDirsFS wraps an fs.FS to skip ignored directories during traversal.
+type skipDirsFS struct {
+	inner fs.FS
+}
+
+func (f skipDirsFS) Open(name string) (fs.File, error) {
+	return f.inner.Open(name)
+}
+
+func (f skipDirsFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := fs.ReadDir(f.inner, name)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]fs.DirEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() && ignoredDirs[entry.Name()] {
+			continue
+		}
+
+		filtered = append(filtered, entry)
+	}
+
+	return filtered, nil
+}
 
 type Tool struct {
 	Name        string
@@ -77,8 +113,9 @@ func (o *Ok) processTool(tl Tool) func() error {
 
 		var filePaths []string
 		var filePathErrs []error
+		fsys := skipDirsFS{inner: os.DirFS(".")}
 		for _, fileGlob := range tl.FileGlobs {
-			globFilePaths, err := doublestar.Glob(os.DirFS("."), fileGlob)
+			globFilePaths, err := doublestar.Glob(fsys, fileGlob)
 
 			filePaths = append(filePaths, globFilePaths...)
 			filePathErrs = append(filePathErrs, err)

--- a/tool_test.go
+++ b/tool_test.go
@@ -3,9 +3,12 @@ package ok
 import (
 	"bytes"
 	"errors"
+	"io/fs"
 	"strings"
 	"testing"
+	"testing/fstest"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -109,4 +112,73 @@ func TestOk_ListTools(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSkipDirsFS(t *testing.T) {
+	inner := fstest.MapFS{
+		"scripts/deploy.sh":                    &fstest.MapFile{},
+		"node_modules/foo/install.sh":          &fstest.MapFile{},
+		"node_modules/bar/postinstall.sh":      &fstest.MapFile{},
+		".git/hooks/pre-commit":                &fstest.MapFile{},
+		"sub/node_modules/pkg/run.sh":          &fstest.MapFile{},
+		"vendor/scripts/build.sh":              &fstest.MapFile{},
+		"top.sh":                               &fstest.MapFile{},
+	}
+
+	fsys := skipDirsFS{inner: inner}
+
+	matches, err := doublestar.Glob(fsys, "**/*.sh")
+	require.NoError(t, err)
+
+	assert.Contains(t, matches, "scripts/deploy.sh")
+	assert.Contains(t, matches, "top.sh")
+	assert.Contains(t, matches, "vendor/scripts/build.sh")
+
+	for _, match := range matches {
+		assert.NotContains(t, match, "node_modules")
+		assert.NotContains(t, match, ".git")
+	}
+}
+
+func TestSkipDirsFS_ReadDir(t *testing.T) {
+	inner := fstest.MapFS{
+		"node_modules/foo/bar.sh": &fstest.MapFile{},
+		".git/hooks/pre-commit":   &fstest.MapFile{},
+		".hg/store/data":          &fstest.MapFile{},
+		".svn/entries":            &fstest.MapFile{},
+		"scripts/deploy.sh":       &fstest.MapFile{},
+		"README.md":               &fstest.MapFile{},
+	}
+
+	fsys := skipDirsFS{inner: inner}
+
+	entries, err := fsys.ReadDir(".")
+	require.NoError(t, err)
+
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name()
+	}
+
+	assert.Contains(t, names, "scripts")
+	assert.Contains(t, names, "README.md")
+	assert.NotContains(t, names, "node_modules")
+	assert.NotContains(t, names, ".git")
+	assert.NotContains(t, names, ".hg")
+	assert.NotContains(t, names, ".svn")
+}
+
+func TestSkipDirsFS_Open(t *testing.T) {
+	inner := fstest.MapFS{
+		"scripts/deploy.sh": &fstest.MapFile{Data: []byte("#!/bin/bash")},
+	}
+
+	fsys := skipDirsFS{inner: inner}
+
+	f, err := fsys.Open("scripts/deploy.sh")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, err = fsys.Open("nonexistent")
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }


### PR DESCRIPTION
## Summary
This PR adds functionality to skip common ignored directories (`.git`, `.hg`, `.svn`, `node_modules`) during file discovery when processing tools. This prevents unnecessary scanning of these directories and improves performance.

## Key Changes
- Added `ignoredDirs` map containing directory names to skip during traversal
- Implemented `skipDirsFS` wrapper type that implements `fs.FS` interface to filter out ignored directories
  - `Open()` method delegates to the inner filesystem
  - `ReadDir()` method filters directory entries, excluding any directories in the `ignoredDirs` map
- Updated `processTool()` to use `skipDirsFS` wrapper when globbing for files instead of using `os.DirFS` directly
- Added comprehensive test coverage:
  - `TestSkipDirsFS` verifies glob patterns work correctly with the wrapper
  - `TestSkipDirsFS_ReadDir` tests directory filtering behavior
  - `TestSkipDirsFS_Open` tests file opening functionality

## Implementation Details
The `skipDirsFS` type wraps an `fs.FS` and intercepts `ReadDir()` calls to filter out ignored directories before returning results. This approach works seamlessly with the `doublestar.Glob()` function, which respects the filtered directory listings during pattern matching.

https://claude.ai/code/session_01UBhWhTmsM5ghP6rcEKLtDT